### PR TITLE
Allow use of boilerplate file fallback also on reading configuration from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,9 +240,11 @@ class RoboFile extends Tasks
 
     public function __construct()
     {
-        // load the configuration for the task (optionally)
+        // load the configuration for the task (optionally) with boilerplate fallback
         // if loading was successful you can use $this->get() in all the following tasks to receive a value
-        $this->loadConfiguration('config.yml');
+        $this
+          ->useBoilerplate('config.dist.yml')
+          ->loadConfiguration('config.yml');
     }
     
     public function foo() {

--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ class RoboFile extends Tasks
         // load the configuration for the task (optionally) with boilerplate fallback
         // if loading was successful you can use $this->get() in all the following tasks to receive a value
         $this
-          ->useBoilerplate('config.dist.yml')
-          ->loadConfiguration('config.yml');
+            ->useBoilerplate('config.dist.yml')
+            ->loadConfiguration('config.yml');
     }
     
     public function foo() {

--- a/src/Boilerplate.php
+++ b/src/Boilerplate.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace NordCode\RoboParameters;
+
+use Robo\Exception\TaskException;
+
+trait Boilerplate
+{
+    /**
+     * @var string
+     */
+    protected $boilerplatePath;
+
+    /**
+     * @var string
+     */
+    protected $boilerplateFormat;
+
+    /**
+     * Configure from which file the basic values will be read from
+     *
+     * @param string $path
+     * @param string|null $format
+     * @return $this
+     */
+    public function useBoilerplate($path, $format = null)
+    {
+      $this->boilerplatePath = $path;
+      $this->boilerplateFormat = $format;
+      return $this;
+    }
+
+    /**
+     * @return array
+     * @throws TaskException
+     */
+    protected function readFromBoilerplate()
+    {
+      if (is_string($this->boilerplatePath)) {
+        if (!file_exists($this->boilerplatePath) || !is_file($this->boilerplatePath)) {
+          throw new TaskException($this, 'Cannot open boilerplate file ' . $this->boilerplatePath);
+        }
+
+        $format = $this->boilerplateFormat ?: Format::guessFormatFromPath($this->boilerplatePath);
+
+        $reader = $this->getReaderRegistry()->getInstanceForFormat($format);
+        return $reader->readFromFile($this->boilerplatePath);
+      } else {
+        return array();
+      }
+    }
+}

--- a/src/FileConfigurable.php
+++ b/src/FileConfigurable.php
@@ -6,6 +6,8 @@ use NordCode\RoboParameters\Reader\ReaderRegistry;
 
 trait FileConfigurable
 {
+    use Boilerplate;
+
     /**
      * @var array
      */
@@ -22,7 +24,7 @@ trait FileConfigurable
         $reader = $readerRegistry->getInstanceForFormat(
             $format ?: Format::guessFormatFromPath($path)
         );
-        $this->configuration = $reader->readFromFile($path);
+        $this->configuration = $reader->readFromFile($path) + $this->readFromBoilerplate();
         return $this;
     }
 

--- a/src/Task/Parameters.php
+++ b/src/Task/Parameters.php
@@ -2,6 +2,7 @@
 
 namespace NordCode\RoboParameters\Task;
 
+use NordCode\RoboParameters\Boilerplate;
 use NordCode\RoboParameters\Format;
 use NordCode\RoboParameters\Reader\ReaderRegistry;
 use NordCode\RoboParameters\Serializer\SerializerRegistry;
@@ -14,6 +15,7 @@ use Robo\Task\BaseTask;
  */
 class Parameters extends BaseTask
 {
+    use Boilerplate;
 
     /**
      * @var array
@@ -39,16 +41,6 @@ class Parameters extends BaseTask
      * @var string
      */
     protected $outputFormat;
-
-    /**
-     * @var string
-     */
-    protected $boilerplatePath;
-
-    /**
-     * @var string
-     */
-    protected $boilerplateFormat;
 
     /**
      * @var bool
@@ -175,20 +167,6 @@ class Parameters extends BaseTask
     }
 
     /**
-     * Configure from which file the basic values will be read from
-     *
-     * @param string $path
-     * @param string|null $format
-     * @return $this
-     */
-    public function useBoilerplate($path, $format = null)
-    {
-        $this->boilerplatePath = $path;
-        $this->boilerplateFormat = $format;
-        return $this;
-    }
-
-    /**
      * Override possible existing output file
      *
      * @return $this
@@ -282,26 +260,6 @@ class Parameters extends BaseTask
         }
 
         return array_replace_recursive($boilerplateParameters, $environmentParameters, $this->parameters);
-    }
-
-    /**
-     * @return array
-     * @throws TaskException
-     */
-    protected function readFromBoilerplate()
-    {
-        if (is_string($this->boilerplatePath)) {
-            if (!file_exists($this->boilerplatePath) || !is_file($this->boilerplatePath)) {
-                throw new TaskException($this, 'Cannot open boilerplate file ' . $this->boilerplatePath);
-            }
-
-            $format = $this->boilerplateFormat ?: Format::guessFormatFromPath($this->boilerplatePath);
-
-            $reader = $this->getReaderRegistry()->getInstanceForFormat($format);
-            return $reader->readFromFile($this->boilerplatePath);
-        } else {
-            return array();
-        }
     }
 
     /**


### PR DESCRIPTION
There are cases in applications where the package is shipped with a boilerplate config file (example `config.dist.yml`) and the install/configure step requires to create a local config (`config.local.yml`) that overrides some of the distribution shipped configuration. For such case it would be helpful to allow usage of boilerplate file in `\NordCode\RoboParameters\FileConfigurable`.

Example:

```php
use Robo\Tasks;

class RoboFile extends Tasks
{
    use \NordCode\RoboParameters\FileConfigurable;

    public function __construct()
    {
        $this
            ->useBoilerplate('config.dist.yml')
            ->loadConfiguration('config.local.yml');
    }
    ...
} 

```